### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/mozilla/payments.png?label=ready&title=Ready)](https://waffle.io/mozilla/payments)
 General root documentation for all Payments.
 
 For more read our docs: http://payments.readthedocs.org/


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/mozilla/payments

This was requested by a real person (user andymckay-limited-access) on waffle.io, we're not trying to spam you.
