### PR TITLE
some general documentation clean up

### DIFF
--- a/docs/design/api/index.rst
+++ b/docs/design/api/index.rst
@@ -1,9 +1,8 @@
-Proposed backend API
+APIs
 ====================
 
 .. toctree::
    :maxdepth: 2
 
    payments
-   provider
    storage

--- a/docs/design/api/payments.rst
+++ b/docs/design/api/payments.rst
@@ -1,52 +1,11 @@
 Payment API
 -----------
 
-This is a rough draft of the backend API for Payments for Firefox Accounts.
-This is based on solitude, but at this point it might not need to be.
+The payments-ui interacts with payments-service,
+its `API docs <https://payments-service.readthedocs.org/en/latest/>`_ provide
+details on how to complete all the tasks needed to complete a payment.
 
-TODO: figure out the appropriate relationship between seller and product.
-
-This is the API needed to have a buyer who has *never purchased* anything with
-Mozilla before complete a subscription sign up.
-
-* **POST /buyer**: create a buyer.
-* **POST /provider/tokenized-payment-method**: A stub for getting tokenized
-  payment data from the provider.
-* **POST /payment**: create a payment method. Requires: buyer, payment
-  method information.
-* **POST /subscription**: create a subscription. Requires: buyer, seller and
-  payment method.
-* **POST /transaction**: create a solitude transaction to start the first
-  subscription. Requires: subscription.
-* **POST /provider/charge-subscription**: tries to run a charge against the
-  subscription at the payment provider.
-* **PATCH /transaction/int:id**: update the transaction with information from
-  the charge attempt. Requires: subscription attempt information.
-
-To create a new payment method:
-
-* **POST /provider/tokenized-payment-method**: A stub for getting tokenized
-  payment data from the provider.
-* **POST /payment**: create a payment method. Requires: buyer, payment
-  information.
-
-To change a subscription method:
-
-* **PATCH /subscription/int:id**: updates the subscription. Requires: new
-  payment method information. The buyer and seller could not be changed.
-
-To cancel a subscription:
-
-* **PATCH /subscription/int:id**: patch a subscription. Requires: new state
-  of subscription active/inactive.
-
-To get a list of all transactions:
-
-* **GET /transaction?buyer=...**: filter buy buyer. This would be paginated, so
-  we should order by newest first.
-
-To get a list of all subscriptions:
-
-* **GET /subscription?buyer=...**: filter buy buyer. This would be paginated,
-  so we should order by newest first.
-
+Payments-service provides the authentication layer around solitude. The
+`API docs <https://solitude.readthedocs.org/en/latest/>`_ for solitude shows
+how to interact with the
+`payment provider <https://solitude.readthedocs.org/en/latest/topics/braintree.html>`_.

--- a/docs/design/design.rst
+++ b/docs/design/design.rst
@@ -5,8 +5,8 @@ Overall design documentation.
 
 Status: **in draft** expect changes.
 
-Purchase flow - FxA
--------------------
+Firefox Accounts login
+----------------------
 
 The flow of OAuth tokens for the purchase flow to allow for a seamless login.
 
@@ -19,10 +19,17 @@ Focusing on showing exposure of credit card details.
 
 .. image:: buy-flow.png
 
+Purchase backend view
+---------------------
+
+This is an example flow of creating a customer, a payment method and a
+subscription to a plan:
+
+.. image:: api/start-subscription.png
+
 Services
 --------
 
 An abstract view of services and what they speak to.
 
 .. image:: abstract.png
-

--- a/docs/design/emails.rst
+++ b/docs/design/emails.rst
@@ -1,27 +1,8 @@
-Backend API
-===========
-
-Solitude API
-------------
-
-The back end API for payments is `solitude <http://solitude.readthedocs.org>`_
-and its `documentation <http://solitude.readthedocs.org/en/latest/topics/braintree.html>`_
-has the API for connecting to Braintree. Solitude makes the Braintree calls and
-stores a bit of information about the response in its database so faster access.
-
-Braintree interaction
-+++++++++++++++++++++
-
-This is an example flow of creating a customer, a payment method and a
-subscription to a plan:
-
-.. image:: start-subscription.png
-
-Events
+Emails
 ------
 
-The backend will need to send the following events, these might be sent as
-emails, or other method, or ignored.
+The backend will need to send the following events to subscribers. Usually as emails.
+These might be sent as emails, or other method, or ignored.
 
 * Payment method created.
 * Payment method updated for subscription.
@@ -30,25 +11,25 @@ emails, or other method, or ignored.
 * Subscription charge failed.
 * Subscription cancelled.
 
-TODO: figure out how solitude would signal out these events.
-
 Payment method created
 ++++++++++++++++++++++
 
-When a new credit card is added event, it’s immediately visible on the purchase flow:
+When a new credit card is added event, it’s immediately visible on the management pages.
 
-.. image:: ux-add-new-card-wireframe.png
+TODO: the image below is out of date.
+
+.. image:: api/ux-add-new-card-wireframe.png
 
 There’s no need to send an email unless we’re concerned about unauthorised access. (For example, Facebook would tell you if you’re signed in from an unknown device.)
 
 Payment method updated for subscription
 +++++++++++++++++++++++++++++++++++++++
 
-Gist: each subscription can be paid with different credit cards. When the credit card change, should we send an email that says “This subscription is now paid using B instead of A”?
+Gist: each subscription can be paid with different credit cards. When the credit card changes, should we send an email that says “This subscription is now paid using B instead of A”?
 
 * If card is updated then immediately used to pay, email receipt will contain the new card information, so no need for separate notification.
 
-.. image:: ux-email-receipt-highlight-payment-method.png
+.. image:: api/ux-email-receipt-highlight-payment-method.png
 
 * If card is updated but not used to pay until sometime afterwards, should we let user know? Probably not.
 
@@ -60,7 +41,7 @@ Subscription created
 
 This notification is already contained within the email receipt. A subscription receipt will have an extra field that says “Next payment":
 
-.. image:: ux-email-receipt-highlight-next-payment.png
+.. image:: api/ux-email-receipt-highlight-next-payment.png
 
 This makes a separate “You’re subscribed to [product]” email unnecessary.
 
@@ -79,7 +60,7 @@ This will need email notification. It should at the very least specify:
 * Payment method used
 * Link to fix it
 
-.. image:: ux-email-receipt-subscription-charge-failed.png
+.. image:: api/ux-email-receipt-subscription-charge-failed.png
 
 On the link to fix it, user can do these things:
 
@@ -93,7 +74,13 @@ I’m not sure where this link should lead to. Should it lead to the buy flow if
 
 Subscription cancelled
 ++++++++++++++++++++++
-No email necessary, but on the subscription cancellation UI (this is relevant in the Dashboard), we should acknowledge two things:
+Subscription cancellation can happen without the users being present. For example the default flow is something like:
+
+* charge fails, notify user
+* 10 days later, charge fails, notify user
+* 20 days later, charge fails, cancel subscription.
+
+In the UI and other elements, we should:
 
 * Reassure user that the payment method is not going to be charged again
 * Reiterate whether the subscription is still valid or not
@@ -101,15 +88,13 @@ No email necessary, but on the subscription cancellation UI (this is relevant in
   * If still valid, then until when? Give exact date
   * If not valid, then we should let it know that subscription will cease the moment user clicks “cancel”
 
-I think this is a job that can be accomplished using a really good subscription cancellation UI. It should say “Your subscription will be valid until [date]/Your subscription will instantly terminate. [Keep my subscription/Cancel]”
-
 Summary
--------
++++++++
 Should we send email notification during this event?
 
 * Payment method created: no
 * Payment method updated for subscription: no
 * Subscription created: no
-* Subscription charge succeeded (e.g. every month): no
+* Subscription charge succeeded (e.g. every month): yes
 * Subscription charge failed: yes
-* Subscription cancelled: no
+* Subscription cancelled: yes

--- a/docs/design/overview.rst
+++ b/docs/design/overview.rst
@@ -102,7 +102,7 @@ easily bring up the iframe for completing the payment flow and then processing
 the completed flow.
 
 * *UX*: :ref:`buy flow <purchase-label>`
-* *Documentation*: ...
+* *Documentation*: https://github.com/mozilla/payments-client/blob/master/README.md
 * *Repository*: https://github.com/mozilla/payments-client
 * *Uptime requirements*: will be hosted on the site selling the product.
 
@@ -112,7 +112,7 @@ Buy flow
 Shown in an iframe to the end user. Triggered by the library.
 
 * *UX*: :ref:`buy flow <purchase-label>`
-* *Documentation*: ...
+* *Documentation*: https://github.com/mozilla/payments-ui/blob/master/README.md
 * *Repository*: https://github.com/mozilla/payments-ui
 * *Uptime requirements*: very high, if this goes out, purchasing will fail. Based also upon
   the uptime of the payment provider and all the stacks inbetween.
@@ -123,9 +123,9 @@ Management screens
 Shown as a standard set of pages. Accessible at a URL and linked from the
 Firefox Accounts profile page.
 
-* *UX*: ...
-* *Documentation*: ...
-* *Repository*:
+* *UX*: :ref:`buy flow <purchase-label>`
+* *Documentation*: https://github.com/mozilla/payments-ui/blob/master/README.md
+* *Repository*: https://github.com/mozilla/payments-ui
 * *Uptime requirements*: high, this doesn't stop purchasing work but prevents
   later management.
 
@@ -146,6 +146,7 @@ Environment
 
 Contains the environment for running the services.
 
+* *Documentation*: https://github.com/mozilla/payments-env/blob/master/README.md
 * *Repository*: https://github.com/mozilla/payments-env
 
 Service

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,11 +6,12 @@ Contents:
 .. toctree::
    :maxdepth: 2
 
-   contributing.rst
    design/overview.rst
-   design/api/index.rst
+   contributing.rst
    design/design.rst
    design/ux.rst
+   design/emails.rst
+   design/api/index.rst
    testing.rst
    onboarding.rst
 


### PR DESCRIPTION
- api/payments.rst didn't have anything useful in it anymore, point to solitude and service docs instead
- move the emails to a document named emails so we can find it
